### PR TITLE
Adapt style for use with jabbrv

### DIFF
--- a/yahapj.bst
+++ b/yahapj.bst
@@ -1008,6 +1008,11 @@ FUNCTION {maybe.doi.link.end}
  if$
 }
 
+FUNCTION {format.journal}
+{
+  "{\JournalTitle{" journal * "}}" *
+}
+
 FUNCTION {article}
 { output.bibitem
   format.authors "author" output.check
@@ -1015,9 +1020,8 @@ FUNCTION {article}
   name.or.dash
   format.date "year" output.check
   crossref missing$
-    { journal
+    { format.journal "journal" output.check
       maybe.doi.link.prepend
-      "journal" output.check
       format.vol.num.pages output
     }
     { format.article.crossref


### PR DESCRIPTION
I adapted the style to work with the [jabbrv](http://www.compholio.com/latex/jabbrv/) package which automatically abbreviates journal names according to ISO 4 / ISSN standard abbreviation rules. Essentially this patch wraps all journal names in \JournalTitle{} command, which is defined by jabbrv. To not use this patch, one would simply 

```
\newcommand\JournalTitle{#1}
```

This should probably be a new branch in the repo as it should be a choice.
