### PR TITLE
yahapj.bst: avoid unwanted comma in entries for two-author papers

### DIFF
--- a/yahapj.bst
+++ b/yahapj.bst
@@ -322,7 +322,7 @@ FUNCTION {format.names}
         namesleft #1 >
           { ", " * t * }
           {
-            numnames #1 >
+            numnames #2 >
               { "," * }
               'skip$
             if$


### PR DESCRIPTION
I don't remember monkeying with this code, so I think this was just a bug in the original style file. Probably other variants have fixed it, but not us. Until now.

Closes #9.